### PR TITLE
Don't add unique prefix to empty string classNames

### DIFF
--- a/src/script-loader.ts
+++ b/src/script-loader.ts
@@ -17,6 +17,7 @@ export default function scriptLoader(this: LoaderContext, source: string): strin
     return source.replace(classExprRegex, classExpr => {
         return classExpr.replace(classStringRegex, (_match, classNames) => {
             const uniqueClassNames = classNames.split(' ')
+                .filter(Boolean)
                 .map((className: string) => {
                     const containsPrefix = className.startsWith(`${globalsPrefix}-`);
                     const uniqueClassName = `${dirName}-${dirHash}-${className}`;


### PR DESCRIPTION
Empty classes should not be processed. 
Expected output

```jsx
<p className="">
```

but not

```jsx
<p className="src-d95e50f610-">
```