### PR TITLE
Don't check for an external path

### DIFF
--- a/src/script-loader.ts
+++ b/src/script-loader.ts
@@ -3,12 +3,11 @@ import { LoaderContext } from './options';
 
 export default function scriptLoader(this: LoaderContext, source: string): string {
     const { globalsPrefix = 'app' } = this.query;
-    const isExternal = !this.resourcePath.startsWith(this.rootContext);
 
     const classExprRegex = /classname:\s(["'].*?["']|.*?\))/gi;
     const classStringRegex = new RegExp(`['|"](.*?)['|"]`, 'g')
 
-    if (isExternal || !source.match(classExprRegex)) {
+    if (!source.match(classExprRegex)) {
         return source;
     }
 


### PR DESCRIPTION
The module path should not be checked by this plugin. Even in normal situation this condition may not pass. For example local module can have an absolute `resourcePath` during the development equal to `'C:\Users\const\Desktop\react\src\components\Input.jsx'` and `rootContext` with value of `undefined`.

Better consumer to setup "include" and "exclude" in the loader configuration by himself